### PR TITLE
use netCDF4 fill values for out_vars

### DIFF
--- a/metsim/constants.py
+++ b/metsim/constants.py
@@ -18,6 +18,23 @@ Stores default constants
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+try:
+    # prefer to just use the dictionary stored in netCDF
+    from netCDF4 import default_fillvals as FILL_VALUES
+except ImportError:
+    # but we can use these if we can't import netCDF4
+    FILL_VALUES = {'S1': '\x00',
+                   'f4': 9.969209968386869e+36,
+                   'f8': 9.969209968386869e+36,
+                   'i1': -127,
+                   'i2': -32767,
+                   'i4': -2147483647,
+                   'i8': -9223372036854775806,
+                   'u1': 255,
+                   'u2': 65535,
+                   'u4': 4294967295,
+                   'u8': 18446744073709551614}
+
 DEG_PER_REV = 360.0       # Number of degrees in full revolution
 SEC_PER_RAD = 13750.9871  # seconds per radian of hour angle
 RAD_PER_DAY = 0.017214    # radians of Earth orbit per julian day

--- a/metsim/metsim.py
+++ b/metsim/metsim.py
@@ -30,7 +30,6 @@ output specified.
 
 import os
 import struct
-import logging
 import itertools
 import time as tm
 from getpass import getuser
@@ -162,7 +161,7 @@ class MetSim(object):
                 data=np.full(shape, np.nan),
                 coords=coords, dims=dims,
                 name=varname, attrs=attrs.get(varname, {}),
-                encoding=None)
+                encoding={'dtype': 'f8', '_FillValue': cnst.FILL_VALUES['f8']})
 
         # Input preprocessing
         in_preprocess = {"ascii": self.vic_in_preprocess,


### PR DESCRIPTION
This PR adds the default netCDF4 fill values to the output netcdf files that are written by metsim. 

 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``

