### PR TITLE
Feature/output filename

### DIFF
--- a/examples/example_nc.conf
+++ b/examples/example_nc.conf
@@ -14,6 +14,7 @@ stop = 1950/1/31
 forcing = ./tests/data/test.nc
 domain  = ./tests/data/domain.nc
 out_dir = ./results
+out_prefix = forcing
 in_format = netcdf
 out_format = netcdf
 
@@ -34,4 +35,3 @@ lat = lat
 lon = lon
 mask = mask
 elev = elev
-

--- a/metsim/constants.py
+++ b/metsim/constants.py
@@ -18,6 +18,23 @@ Stores default constants
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+try:
+    # prefer to just use the dictionary stored in netCDF
+    from netCDF4 import default_fillvals as FILL_VALUES
+except ImportError:
+    # but we can use these if we can't import netCDF4
+    FILL_VALUES = {'S1': '\x00',
+                   'f4': 9.969209968386869e+36,
+                   'f8': 9.969209968386869e+36,
+                   'i1': -127,
+                   'i2': -32767,
+                   'i4': -2147483647,
+                   'i8': -9223372036854775806,
+                   'u1': 255,
+                   'u2': 65535,
+                   'u4': 4294967295,
+                   'u8': 18446744073709551614}
+
 DEG_PER_REV = 360.0       # Number of degrees in full revolution
 SEC_PER_RAD = 13750.9871  # seconds per radian of hour angle
 RAD_PER_DAY = 0.017214    # radians of Earth orbit per julian day

--- a/metsim/metsim.py
+++ b/metsim/metsim.py
@@ -30,7 +30,6 @@ output specified.
 
 import os
 import struct
-import logging
 import itertools
 import time as tm
 from getpass import getuser
@@ -162,7 +161,7 @@ class MetSim(object):
                 data=np.full(shape, np.nan),
                 coords=coords, dims=dims,
                 name=varname, attrs=attrs.get(varname, {}),
-                encoding=None)
+                encoding={'dtype': 'f8', '_FillValue': cnst.FILL_VALUES['f8']})
 
         # Input preprocessing
         in_preprocess = {"ascii": self.vic_in_preprocess,

--- a/metsim/metsim.py
+++ b/metsim/metsim.py
@@ -83,6 +83,7 @@ class MetSim(object):
         "method": '',
         "domain": '',
         "out_dir": '',
+        "out_prefix": 'forcing',
         "start": '',
         "stop": '',
         "time_step": '',
@@ -309,8 +310,8 @@ class MetSim(object):
     def netcdf_out_preprocess(self):
         """Initialize the output file"""
         print("Initializing netcdf...")
-        self.output_filename = os.path.join(self.params['out_dir'],
-                                            "forcing.nc")
+        self.output_filename = os.path.join(
+            self.params['out_dir'], '{}.nc'.format(self.params['out_prefix']))
 
     def write(self):
         """
@@ -338,8 +339,9 @@ class MetSim(object):
             if self.output.mask[i, j] > 0:
                 lat = self.output.lat.values[i]
                 lon = self.output.lon.values[j]
-                fname = os.path.join(self.params['out_dir'],
-                                     "forcing_{}_{}.csv".format(lat, lon))
+                fname = os.path.join(
+                    self.params['out_dir'],
+                    "{}_{}_{}.csv".format(self.params['out_prefix'], lat, lon))
                 self.output.isel(lat=i, lon=j)[self.params[
                     'out_vars']].to_dataframe().to_csv(fname)
 

--- a/tests/test_metsim.py
+++ b/tests/test_metsim.py
@@ -95,6 +95,7 @@ def test_params(in_format, out_format, method):
     in_vars = in_vars_section[in_format]
     domain_vars = domain_section[in_format]
     out_dir = "./tmp"
+    out_prefix = "forcing"
     lr = 0.0065
     params = {'start': start,
               'stop': stop,
@@ -107,6 +108,7 @@ def test_params(in_format, out_format, method):
               't_max_lr': lr,
               't_min_lr': lr,
               'out_dir': out_dir,
+              'out_prefix': out_prefix,
               'in_vars': in_vars,
               'domain_vars': domain_vars}
     return params


### PR DESCRIPTION
Added a new feature and configuration option allowing users to specify the prefix of the netcdf/ascii file they wish to write out. The default value remains `forcing` as in previous versions of metsim.

 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``

