### PR TITLE
Refactor/parallel update

### DIFF
--- a/metsim/constants.py
+++ b/metsim/constants.py
@@ -84,4 +84,4 @@ RAIN_SCALAR = 0.75  # (dim) correction to trans. for rain day
 DIF_ALB = 0.6       # (dim) diffuse albedo for horizon correction
 SC_INT = 1.32       # (MJ/m2/day) snow correction intercept
 SC_SLOPE = 0.096    # (MJ/m2/day/cm) snow correction slope
-CHUNK_SIZE = 10
+CHUNK_SIZE = 1 

--- a/metsim/metsim.py
+++ b/metsim/metsim.py
@@ -214,7 +214,6 @@ class MetSim(object):
         """
         Kicks off the disaggregation and queues up data for IO
         """
-        results = []
         for i, j in locations:
             locs = dict(lat=i, lon=j)
             print("Processing {}".format(locs))
@@ -224,8 +223,7 @@ class MetSim(object):
             df = ds.drop(['lat', 'lon', 'elev']).to_dataframe()
             df = self.method.run(df, MetSim.params, elev=elev,
                                  lat=lat, disagg=self.disagg)
-            results.append((locs, df))
-        self._unpack_results(results)
+            self._unpack_results((locs, df))
 
     def find_elevation(self, lat: float, lon: float) -> float:
         """ Use the domain file to get the elevation """
@@ -461,4 +459,4 @@ def wrap_run(func: callable, loc: dict,
     elev = ds['elev'].values
     df = ds.drop(['lat', 'lon', 'elev']).to_dataframe()
     df = func(df, MetSim.params, elev=elev, lat=lat, disagg=disagg)
-    return loc, df
+    return (loc, df)


### PR DESCRIPTION
This PR does away with the domain decomposition using `CHUNK_SIZE`. While I liked where we were headed with the previous approach, it had a fatal flaw, it passed the full forcing dataset across processes and for large datasets, this crashed (`PickleError`). So what I've done here is sacrifice some efficiency for operability.  I'll open an issue to revisit this subject.
