### PR TITLE
Allow for swe to be given as timeseries.

### DIFF
--- a/metsim/metsim.py
+++ b/metsim/metsim.py
@@ -308,6 +308,7 @@ class MetSim(object):
         self.met_data['smoothed_dtr'] = sm_dtr
 
         # Put in SWE data
+        self.state['swe'] = self.state.sel(time=end_record).swe.drop('time')
         self.met_data['swe'] = self.state.swe.copy()
 
     def _validate_setup(self):

--- a/metsim/metsim.py
+++ b/metsim/metsim.py
@@ -291,8 +291,8 @@ class MetSim(object):
                                   calendar=self.params['calendar'])
         trailing = self.state['prec'].sel(time=record_dates)
         total_precip = xr.concat([trailing, self.met_data['prec']], dim='time')
-        total_precip = total_precip.rolling(time=90).sum().drop(record_dates,
-                                                                dim='time')
+        total_precip = (cnst.DAYS_PER_YEAR * total_precip.rolling(
+            time=90).mean().drop(record_dates, dim='time'))
         self.met_data['seasonal_prec'] = total_precip
 
         # Smoothed daily temperature range

--- a/tests/test_metsim.py
+++ b/tests/test_metsim.py
@@ -64,7 +64,7 @@ data_ranges = {'temp': (-50, 40),
                'shortwave': (0, 1000),
                'longwave': (0, 450),
                'wind': (0, 10),
-               'vapor_pressure': (0, 1.4),
+               'vapor_pressure': (0, 1.6),
                'rel_humid': (0, 100)}
 
 


### PR DESCRIPTION
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``

Previously, if the `swe` variable was given with a `time` dimension, then MetSim would complain on trying to unpack it back into the `state` dataset.  This fixes that.
