### PR TITLE
Fix compatibility with future array

### DIFF
--- a/metsim/metsim.py
+++ b/metsim/metsim.py
@@ -371,7 +371,7 @@ class MetSim(object):
             state_start, result.index[-1], calendar=self.params['calendar'])
 
     def setup_output(self, prototype: xr.Dataset=None):
-        if not prototype:
+        if not prototype.variables:
             prototype = self.met_data
         self.disagg = int(self.params['time_step']) < cnst.MIN_PER_DAY
         # Number of timesteps
@@ -540,7 +540,7 @@ class MetSim(object):
 
         # all state variables are written as doubles
         state_encoding = {}
-        for v in self.state:
+        for v in self.state.variables:
             state_encoding[v] = {'dtype': 'f8'}
         state_encoding['time']['calendar'] = self.params['calendar']
         # write state file
@@ -567,7 +567,7 @@ class MetSim(object):
             os.makedirs(dirname, exist_ok=True)
         # all state variables are written as doubles
         state_encoding = {'time': {'dtype': 'f8'}}
-        for v in self.state:
+        for v in self.state.variables:
             state_encoding[v] = {'dtype': 'f8'}
         # write state file
         self.state.to_netcdf(self.params['out_state'], encoding=state_encoding)


### PR DESCRIPTION
 - [ ] closes #xxxx
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [ ] whatsnew entry

Edited lines 374, 543, and 570 of `metsim.py` to cast Dataset.variables as a boolean and iterate over Dataset.variables, respectively, in response to upcoming change in `xarray` that will no longer allow those actions on xarray.Dataset.

Fixes the following runtime errors (develop branch, commit 6282cfdc5479a7c5ad2525851c7f3a704747e5d9):
> /mydir/python3.6/site-packages/metsim-1.0.0-py3.6.egg/metsim/metsim.py:374:
>FutureWarning: casting an xarray.Dataset to a boolean will change in xarray v0.11 to only include data variables, not coordinates. Cast the Dataset.variables property instead to preserve existing behavior in a forwards compatible manner.
>/mydir/python3.6/site-packages/metsim-1.0.0-py3.6.egg/metsim/metsim.py:543: FutureWarning: iteration over an xarray.Dataset will change in xarray v0.11 to only include data variables, not coordinates. Iterate over the Dataset.variables property instead to preserve existing behavior in a forwards compatible manner.
