### PR TITLE
Updated to include new "mix" option for prec_type and updated citation.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -123,13 +123,15 @@ one of the following: ``uniform``, ``triangle``, or ``mix``. Defaults to
 precipitation is disaggregated by dividing uniformly over all sub-daily
 timesteps. Under ``triangle`` the "triangle" method is employed whereby daily
 precipitation is distributed assuming an isosceles triangle shape with peak and
-width determined from two domain variables, ``t_pk`` and ``dur``. For more
-information about the "triangle" method see :doc:`PtriangleMethod.pdf`. Under
+width determined from two domain variables, ``t_pk`` and ``dur``.  Under
 ``mix``, the "uniform" method is used on days when ``t_min`` < 0 C, and
 "triangle" is used on all other days; this hybrid method retains the improved
 accuracy of "triangle" in terms of warm season runoff but avoids the biases
 in snow accumulation that the "triangle" method sometimes yields due to fixed
-event timing within the diurnal cycle of temperature.
+event timing within the diurnal cycle of temperature. A domain file for the
+CONUS+Mexico domain, containing the ``dur`` and ``t_pk`` parameters is
+available at: `<https://zenodo.org/record/1402223#.XEI-mM2IZPY>`.  For more
+information about the "triangle" method see :doc:`PtriangleMethod.pdf`.
 
 For more information about input and output variables see the :ref:`data` page.
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -118,13 +118,18 @@ simulation method is used, as well as whether disaggregation is used. Defaults
 to ``['temp', 'prec', 'shortwave', 'longwave', 'vapor_pressure', 'red_humid']``.
 
 ``prec_type :: str``: Type of precipitation disaggregation method to use. Can be
-one of the following: ``uniform`` or ``triangle``. Defaults to ``uniform``.
-Capitalization does not matter. Under ``uniform`` method, precipitation is
-disaggregated by dividing uniformly over all sub-daily timesteps. Under
-``triangle`` the "triangle" method is employed whereby daily precipitation is
-distributed assuming an isosceles triangle shape with peak and width determined
-from two domain variables, ``t_pk`` and ``dur``. For more information about the
-"triangle" method see :doc:`PtriangeMethod.pdf`.
+one of the following: ``uniform``, ``triangle``, or ``mix``. Defaults to
+``uniform``.  Capitalization does not matter. Under ``uniform`` method,
+precipitation is disaggregated by dividing uniformly over all sub-daily
+timesteps. Under ``triangle`` the "triangle" method is employed whereby daily
+precipitation is distributed assuming an isosceles triangle shape with peak and
+width determined from two domain variables, ``t_pk`` and ``dur``. For more
+information about the "triangle" method see :doc:`PtriangleMethod.pdf`. Under
+``mix``, the "uniform" method is used on days when ``t_min`` < 0 C, and
+"triangle" is used on all other days; this hybrid method retains the improved
+accuracy of "triangle" in terms of warm season runoff but avoids the biases
+in snow accumulation that the "triangle" method sometimes yields due to fixed
+event timing within the diurnal cycle of temperature.
 
 For more information about input and output variables see the :ref:`data` page.
 
@@ -178,6 +183,6 @@ entries should be of the form ``netcdf_varname = metsim_varname``. The minimum
 required variables have ``metsim_varname``\s corresponding to ``lat``, ``lon``,
 ``mask``, and ``elev``; these variable names correspond to latitude, longitude,
 a mask of valid cells in the domain, and the elevation given in meters. If
-``prec_type`` = ``triangle``, two additonal variables are required including
-``dur`` and ``t_pk`` for disaggregating daily precipitation according to the
-"triangle" method.
+``prec_type`` = ``triangle`` or ``mix``, two additonal variables are required
+including ``dur`` and ``t_pk`` for disaggregating daily precipitation according
+to the "triangle" method.

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -25,7 +25,7 @@ Domain file
 Specified as ``domain`` in the configuration file. The domain file provides
 information about the domain MetSim is to be run over. It is required to be a
 NetCDF file. The domain requires two variables to be valid, or four if
-``prec_type`` = ``triangle``.
+``prec_type`` = ``triangle`` or ``mix``.
 
 First, is the ``mask`` variable, which provides information about which grid
 cells are valid to run MetSim on. Values that specify grid cells which should be
@@ -36,19 +36,19 @@ Second, is the ``elev`` variable. This provides elevation data used for
 calculation of solar geometry. It should be specified in meters, and only needs
 to be given at sites which are marked to be processed via the ``mask`` variable.
 
-Third if ``prec_type`` = ``triangle``, is the ``dur`` variable. This provides
-the climatological monthly storm event duration (in minutes) used for
+Third if ``prec_type`` = ``triangle`` or ``mix``, is the ``dur`` variable. This
+provides the climatological monthly storm event duration (in minutes) used for
 disaggregating daily precipitation according to the "triangle" method. Requires
 one value for each month (12).
 
-Forth if ``prec_type`` = ``triangle``, is the ``t_pk`` variable. This provides
-the climatological monthly time to storm peak (in minutes) use for
-disaggregating daily precipitation to sub-daily time scales using the "triangle"
-method. Requires one value for each month (12).
+Fourth if ``prec_type`` = ``triangle`` or ``mix``, is the ``t_pk`` variable.
+This provides the climatological monthly time to storm peak (in minutes) use
+for disaggregating daily precipitation to sub-daily time scales using the
+"triangle" method. Requires one value for each month (12).
 
 For more information about the "triangle" method see
 `this description <PtriangleMethod.pdf>`_. If you use this feature, please
-cite Bohn et al. (2018) as listed in the `references <index.rst#id10>`_.
+cite Bohn et al. (2019) as listed in the `references <index.rst#id10>`_.
 
 
 It is important to ensure that all valid locations in ``mask`` have data in

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -24,35 +24,40 @@ Domain file
 -----------
 Specified as ``domain`` in the configuration file. The domain file provides
 information about the domain MetSim is to be run over. It is required to be a
-NetCDF file. The domain requires two variables to be valid, or four if
-``prec_type`` = ``triangle`` or ``mix``.
+NetCDF file. The domain requires the following variables to be valid:
 
-First, is the ``mask`` variable, which provides information about which grid
-cells are valid to run MetSim on. Values that specify grid cells which should be
-processed are specified via a positive, finite number (one or greater). Cells
-which MetSim should ignore can be given as 0 or ``NaN``.
+1. ``mask``: This provides information about which grid cells are valid to run
+MetSim on. Values that specify grid cells which should be processed are
+specified via a positive, finite number (one or greater). Cells which MetSim
+should ignore can be given as 0 or ``NaN``.
 
-Second, is the ``elev`` variable. This provides elevation data used for
-calculation of solar geometry. It should be specified in meters, and only needs
-to be given at sites which are marked to be processed via the ``mask`` variable.
+It is important to ensure that all valid locations in ``mask`` have data in
+``elev`` and any other variables.  Failure to ensure this will result in
+errors during runtime.
 
-Third if ``prec_type`` = ``triangle`` or ``mix``, is the ``dur`` variable. This
-provides the climatological monthly storm event duration (in minutes) used for
-disaggregating daily precipitation according to the "triangle" method. Requires
-one value for each month (12).
+2. ``elev``: This provides elevation data (in m) used for calculation of solar
+geometry. It only needs to be given at sites which are marked to be processed
+via the ``mask`` variable.
 
-Fourth if ``prec_type`` = ``triangle`` or ``mix``, is the ``t_pk`` variable.
-This provides the climatological monthly time to storm peak (in minutes) use
-for disaggregating daily precipitation to sub-daily time scales using the
+The next two variables are only needed if ``prec_type`` = ``triangle`` or
+``mix`` in the input file:
+
+3. ``dur``: This provides the climatological monthly storm event duration (in
+minutes) used for disaggregating daily precipitation according to the
 "triangle" method. Requires one value for each month (12).
+
+4. ``t_pk``: This provides the climatological monthly time to storm peak (in
+minutes starting from midnight) used for disaggregating daily precipitation to
+sub-daily time scales using the "triangle" method. Requires one value for
+each month (12).
 
 For more information about the "triangle" method see
 `this description <PtriangleMethod.pdf>`_. If you use this feature, please
 cite Bohn et al. (2019) as listed in the `references <index.rst#id10>`_.
 
-
-It is important to ensure that all valid locations in ``mask`` have data in
-``elev``.  Failure to ensure this will result in errors during runtime.
+A domain file for the CONUS+Mexico domain, at 0.0625 degree resolution, and
+containing ``dur`` and ``t_pk`` values, is available `here
+<https://zenodo.org/record/1402223#.XEZC4M2IZPY>`_.
 
 State file
 ----------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,9 +49,9 @@ component of MetSim can be disaggregated down to sub-daily values at
 intervals specified in minutes (provided they divide evenly into 24
 hours).  The operation of these algorithms is also described in [1]_.
 
-For the "triangle" method of precipitation disaggregation, doumentation
-can be found `here <PtriangleMethod.pdf>`_. This will eventually be superceded
-by a journal article that is currently in review [7]_.
+For the "triangle" and "mix" methods of precipitation disaggregation,
+doumentation can be found `here <PtriangleMethod.pdf>`_. This will eventually
+be superceded by a journal article that is currently in review [7]_.
 
 This documentation is a work in progress.
 If you don't find what you're looking for here, check out MetSim's Github page.
@@ -134,9 +134,10 @@ References
        temperature, humidity, and precipitation. Agricultural and Forest
        Meteorology, 93:211-228.
 
-.. [7] Bohn, T. J., K. M. Whitney, G. Mascaro, and E. R. Vivoni, 2018. A simple
-       approach for approximating the diurnal cycle of precipitation for large-
-       scale hydrological simulations. Journal of Hydrometeorology (submitted).
+.. [7] Bohn, T. J., K. M. Whitney, G. Mascaro, and E. R. Vivoni, 2019. A
+       deterministic approach for approximating the diurnal cycle of 
+       precipitation for large-scale hydrological simulations. Journal of
+       Hydrometeorology (accepted). doi: 10.1175/JHM-D-18-0203.1.
 
 Sitemap
 =======

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -13,15 +13,15 @@ Enhancements
 
 - Added option to disaggregate precipitation via a triangular hyetograph.
   (:issue:`42`).
-  By `Kristen Whitney <https://github.com/kwhitney727>` and `Theodore Bohn
-  <https://github.com/tbohn>`
+  By `Kristen Whitney <https://github.com/kwhitney727>`_ and `Theodore Bohn
+  <https://github.com/tbohn>`_.
 
 Bug fixes
 ~~~~~~~~~
 - Fixed a bug where if `iter_dims` is not `[lat, lon]` the selected `lat` value
   that goes into `solar_geom` ends up as a list. The fix is also added for elevation
   and longitude, for redundancy.  Fixes :issue:`132`.
-  By `Andrew Bennett <https://github.com/arbennett>`
+  By `Andrew Bennett <https://github.com/arbennett>`_.
 
 
 .. _whats-new.1.1.0:
@@ -37,7 +37,7 @@ Enhancements
 - Added option a flexible time grouper when chunking MetSim runs (:issue:`93`).
   By `Joe Hamman <https://github.com/jhamman>`_.
 - Improved configuration validation by checking for correctness of output variables (:issue:`96`)
-  By `Andrew Bennett <https://github.com/arbennett>`
+  By `Andrew Bennett <https://github.com/arbennett>`_.
 - Added option to skip reading ``swe`` variable from state file if it is not
   going to be used by MtClim. (:issue:`103`). By `Joe Hamman <https://github.com/jhamman>`_.
 - Added support for supplying a glob-like file path or multiple input forcing

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -8,6 +8,14 @@ What's New
 v.1.1.1
 -------
 
+Enhancements
+~~~~~~~~~~~~
+
+- Added option to disaggregate precipitation via a triangular hyetograph.
+  (:issue:`42`).
+  By `Kristen Whitney <https://github.com/kwhitney727>` and `Theodore Bohn
+  <https://github.com/tbohn>`
+
 Bug fixes
 ~~~~~~~~~
 - Fixed a bug where if `iter_dims` is not `[lat, lon]` the selected `lat` value

--- a/metsim/metsim.py
+++ b/metsim/metsim.py
@@ -284,7 +284,7 @@ class MetSim(object):
                 if not self.domain['mask'].sel(**locs).values > 0:
                     continue
 
-                if self.params['prec_type'].upper() == 'TRIANGLE':
+                if self.params['prec_type'].upper() in ['TRIANGLE', 'MIX']:
                     # add variables for triangle precipitation disgregation
                     # method to parameters
                     self.params['dur'], self.params['t_pk'] = (
@@ -332,8 +332,7 @@ class MetSim(object):
                 if not self.domain['mask'].sel(**locs).values > 0:
                     continue
 
-                if self.params['prec_type'].upper() == 'TRIANGLE':
-                    print('prec type is triangle')
+                if self.params['prec_type'].upper() in ['TRIANGLE', 'MIX']:
                     # add variables for triangle precipitation disgregation
                     # method to parameters
                     self.params['dur'], self.params['t_pk'] = (


### PR DESCRIPTION
 - [x] closes #152 
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

This PR implements a new `mix` option for `prec_type` that blends the `uniform` and `triangle` P disaggregation approaches.

The `triangle` method, while more accurate under warm conditions, can yield biases in snow accumulation on days when the diurnal cycle of T passes through freezing. On such days, holding event timing fixed in either the warm or cold parts of the diurnal cycle can lead to biases in rain/snow partitioning, if observed event timing varies substantially from one day to the next (which it generally does).

This new `mix` option fixes this bias by using the `uniform` method on days for which `t_min < 0 C` and `triangle` method on all other days.