### PR TITLE
Use args argument for parse_args

### DIFF
--- a/metsim/cli/ms.py
+++ b/metsim/cli/ms.py
@@ -51,7 +51,7 @@ def parse(args):
     parser.add_argument('--version', action='version',
                         version='{} {}'.format(__name__, __version__),
                         help='Name and version number')
-    return parser.parse_args()
+    return parser.parse_args(args)
 
 
 def init(opts):


### PR DESCRIPTION
This small fix makes sure that the `parse(args)` function uses the given `args`

 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master | flake8 --diff``
 - [ ] whatsnew entry
