### PR TITLE
Fixed Disaggregate.py for Passthrough of Daily Mean Shortwave Calculated from Entire Day

### DIFF
--- a/metsim/disaggregate.py
+++ b/metsim/disaggregate.py
@@ -62,8 +62,6 @@ def disaggregate(df_daily: pd.DataFrame, params: dict,
     df_disagg:
         A dataframe with sub-daily timeseries.
     """
-    if params['method'] == 'passthrough':
-        df_daily['daylength'] = 86400.0
     stop = (df_daily.index[-1] + pd.Timedelta('1 days') -
             pd.Timedelta("{} minutes".format(params['time_step'])))
     dates_disagg = date_range(df_daily.index[0], stop,
@@ -73,6 +71,8 @@ def disaggregate(df_daily: pd.DataFrame, params: dict,
     n_days = len(df_daily)
     n_disagg = len(df_disagg)
     ts = int(params['time_step'])
+    #if params['method'] == 'passthrough':
+    df_daily['daylength'] = 86400.0
     df_disagg['shortwave'] = shortwave(df_daily['shortwave'].values,
                                        df_daily['daylength'].values,
                                        df_daily.index.dayofyear,

--- a/metsim/disaggregate.py
+++ b/metsim/disaggregate.py
@@ -639,7 +639,7 @@ def shortwave(sw_rad: np.array, daylength: np.array, day_of_year: np.array,
     if params['method'] == 'mtclim' or params.get('sw_averaging', '') == 'daylight':
         tmp_rad = (sw_rad * daylength) / (cnst.SEC_PER_HOUR * ts_hourly)
     else:
-        tmp_rad = sw_rad * 24
+        tmp_rad = (sw_rad * daylength) / (cnst.SEC_PER_HOUR * ts_hourly) #tmp_rad = sw_rad * 24
     n_days = len(tmp_rad)
     ts_per_day = int(cnst.HOURS_PER_DAY * cnst.MIN_PER_HOUR / ts)
     disaggrad = np.zeros(int(n_days * ts_per_day))

--- a/metsim/disaggregate.py
+++ b/metsim/disaggregate.py
@@ -71,8 +71,9 @@ def disaggregate(df_daily: pd.DataFrame, params: dict,
     n_days = len(df_daily)
     n_disagg = len(df_disagg)
     ts = int(params['time_step'])
-    #if params['method'] == 'passthrough':
-    df_daily['daylength'] = 86400.0
+    ### assume passthrough implies shortwave was computed using entire day not just daylight like mtclim uses to derive its shortwave
+    if params['method'] == 'passthrough':
+      df_daily['daylength'] = 86400.0
     df_disagg['shortwave'] = shortwave(df_daily['shortwave'].values,
                                        df_daily['daylength'].values,
                                        df_daily.index.dayofyear,
@@ -639,6 +640,7 @@ def shortwave(sw_rad: np.array, daylength: np.array, day_of_year: np.array,
     if params['method'] == 'mtclim' or params.get('sw_averaging', '') == 'daylight':
         tmp_rad = (sw_rad * daylength) / (cnst.SEC_PER_HOUR * ts_hourly)
     else:
+        ### if passthrough, still want to do this...but rather than using dailylight daylength uses entire day     
         tmp_rad = (sw_rad * daylength) / (cnst.SEC_PER_HOUR * ts_hourly) #tmp_rad = sw_rad * 24
     n_days = len(tmp_rad)
     ts_per_day = int(cnst.HOURS_PER_DAY * cnst.MIN_PER_HOUR / ts)

--- a/metsim/disaggregate.py
+++ b/metsim/disaggregate.py
@@ -72,7 +72,7 @@ def disaggregate(df_daily: pd.DataFrame, params: dict,
     n_disagg = len(df_disagg)
     ts = int(params['time_step'])
     ### assume passthrough implies shortwave was computed using entire day not just daylight like mtclim uses to derive its shortwave
-    if params['method'] == 'passthrough':
+    if (params['method'] == 'passthrough') & (params.get('sw_averaging', '') != 'daylight'):
       df_daily['daylength'] = 86400.0
     df_disagg['shortwave'] = shortwave(df_daily['shortwave'].values,
                                        df_daily['daylength'].values,

--- a/metsim/disaggregate.py
+++ b/metsim/disaggregate.py
@@ -62,6 +62,8 @@ def disaggregate(df_daily: pd.DataFrame, params: dict,
     df_disagg:
         A dataframe with sub-daily timeseries.
     """
+    if params['method'] == 'passthrough':
+        df_daily['daylength'] = 86400.0
     stop = (df_daily.index[-1] + pd.Timedelta('1 days') -
             pd.Timedelta("{} minutes".format(params['time_step'])))
     dates_disagg = date_range(df_daily.index[0], stop,


### PR DESCRIPTION
I made more commits then needed (first time updating code)...so you may want to just add the code that I've updated in the commit...Notice, the if/else statements are the same - crucial to allow for daily mean shortwave to be disaggregated correctly using passthrough, so those lines of code could be shortened. 

https://github.com/UW-Hydro/MetSim/commit/2560937baf1c2d9dec665c0827c799efe5dc4a1a

This fix allows for daily mean shortwave computed from entire day (86400.0 seconds) to be used as input for passthrough and result in correct output...Current master of MetSim does not computes larger than realistic fluctuations in hourly shortwave for such a case.