### PR TITLE
Update for pandas==2.0.2 compatibility Issue #258

### DIFF
--- a/metsim/datetime.py
+++ b/metsim/datetime.py
@@ -9,7 +9,7 @@ DEFAULT_ORIGIN = '0001-01-01'
 
 
 def date_range(start=None, end=None, periods=None, freq='D', tz=None,
-               normalize=False, name=None, closed=None, calendar='standard',
+               normalize=False, name=None, inclusive='both', calendar='standard',
                **kwargs):
     ''' Return a fixed frequency datetime index, with day (calendar) as the
     default frequency
@@ -31,9 +31,8 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
         Normalize start/end dates to midnight before generating date range
     name : str, default None
         Name of the resulting index
-    closed : string or None, default None
-        Make the interval closed with respect to the given frequency to
-        the 'left', 'right', or both sides (None)
+    inclusive : str {“both”, “neither”, “left”, “right”}, default 'both'
+        Include boundaries; Whether to set each bound as closed or open, both as default
     calendar : string
         Describes the calendar used in the time calculations. Default is a the
         standard calendar (with leap years)
@@ -51,7 +50,7 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
     if calendar in ['standard', 'gregorian', 'propoleptic_gregorian']:
         return pd.date_range(start=start, end=end, periods=periods,
                              freq=freq, tz=tz, normalize=normalize, name=name,
-                             closed=closed, **kwargs)
+                             inclusive=inclusive, **kwargs)
     else:
         # start and end are give
         if (start is not None) and (end is not None) and (periods is None):

--- a/metsim/io.py
+++ b/metsim/io.py
@@ -287,7 +287,7 @@ def read_netcdf(data_handle, domain=None, is_worker=False,
         if isinstance(ds.indexes['time'], xr.CFTimeIndex):
             ds['time'] = ds.indexes['time'].to_datetimeindex()
         ds['time'] = (ds.indexes['time'] -
-                      pd.Timedelta('11H59M59S')).round('D')
+                      pd.Timedelta(hours=11, minutes=59, seconds=59)).round('D')
 
     if var_dict is not None:
         var_list = list(var_dict.keys())


### PR DESCRIPTION
Two changes to address issues with updated pandas. 

First change: Updated date_range function to support inclusive parameter

Details:
The date_range function has been modified to include the inclusive parameter which controls whether to set each bound as closed or open. This parameter replaces the closed parameter which previously served a similar purpose.

The possible values for the inclusive parameter are:

"both": Both bounds are closed (inclusive).
"neither": Both bounds are open (exclusive).
"left": The left bound is closed (inclusive) and the right bound is open (exclusive).
"right": The right bound is closed (inclusive) and the left bound is open (exclusive).

This updates a default argument, which does not appear to require modification to any other function calls in MetSim. This could be checked further.

Second change: Refactored pd.Timedelta in ds['time'] calculation

Details:
The line of code that modifies the 'time' field in the ds dataframe has been updated. The code now uses the named parameter version of the pd.Timedelta function instead of the string-based version.

Previously, the timedelta of '11 hours, 59 minutes, and 59 seconds' was represented as a string '11H59M59S'. The new version of the code provides the hours, minutes, and seconds as explicit arguments. This avoids an issue and raised with the ambuiguity of 'M'.

ds['time'] = (ds.indexes['time'] - pd.Timedelta(hours=11, minutes=59, seconds=59)

These changes were tested only in a local, personal MetSim workflow with pandas==2.0.2.
